### PR TITLE
Update to modern PHP password storage

### DIFF
--- a/php/Modules/Album.php
+++ b/php/Modules/Album.php
@@ -573,9 +573,8 @@ final class Album {
 		Plugins::get()->activate(__METHOD__, 1, func_get_args());
 
 		// Check if password is correct
-		if ($album->password=='') return true;
-		if ($album->password===crypt($password, $album->password)) return true;
-		return false;
+		if ($album->password==='') return true;
+		return password_verify($password, $album->password);
 
 	}
 

--- a/php/Modules/Session.php
+++ b/php/Modules/Session.php
@@ -74,16 +74,11 @@ final class Session {
 		// Call plugins
 		Plugins::get()->activate(__METHOD__, 0, func_get_args());
 
-		$username_crypt = crypt($username, Settings::get()['username']);
-		$password_crypt = crypt($password, Settings::get()['password']);
-
-		// Check login with crypted hash
-		if (Settings::get()['username']===$username_crypt&&
-			Settings::get()['password']===$password_crypt) {
-				$_SESSION['login']      = true;
-				$_SESSION['identifier'] = Settings::get()['identifier'];
-				Log::notice(Database::get(), __METHOD__, __LINE__, 'User (' . $username . ') has logged in from ' . $_SERVER['REMOTE_ADDR']);
-				return true;
+		if (password_verify($username, Settings::get()['username']) and password_verify($password, Settings::get()['password'])) {
+			$_SESSION['login']      = true;
+			$_SESSION['identifier'] = Settings::get()['identifier'];
+			Log::notice(Database::get(), __METHOD__, __LINE__, 'User (' . $username . ') has logged in from ' . $_SERVER['REMOTE_ADDR']);
+			return true;
 		}
 
 		// No login
@@ -96,7 +91,6 @@ final class Session {
 		Log::error(Database::get(), __METHOD__, __LINE__, 'User (' . $username . ') has tried to log in from ' . $_SERVER['REMOTE_ADDR']);
 
 		return false;
-
 	}
 
 	/**

--- a/php/Modules/Settings.php
+++ b/php/Modules/Settings.php
@@ -65,10 +65,9 @@ final class Settings {
 	 * Exits on error.
 	 * @return true Returns true when successful.
 	 */
-	public static function setLogin($oldPassword = '', $username, $password) {
+	public static function setLogin($oldPassword, $username, $password) {
 
-		if ($oldPassword===self::get()['password']||self::get()['password']===crypt($oldPassword, self::get()['password'])) {
-
+		if ((self::get()['password'] === '') or password_verify($oldPassword, self::get()['password'])) {
 			// Save username
 			if (self::setUsername($username)===false) Response::error('Updating username failed!');
 
@@ -76,7 +75,6 @@ final class Settings {
 			if (self::setPassword($password)===false) Response::error('Updating password failed!');
 
 			return true;
-
 		}
 
 		Response::error('Current password entered incorrectly!');

--- a/php/helpers/getHashedString.php
+++ b/php/helpers/getHashedString.php
@@ -1,36 +1,7 @@
 <?php
 
+// We only support >= PHP5.5 
+// Use sane defaults for password_hash
 function getHashedString($password) {
-
-	// Inspired by http://alias.io/2010/01/store-passwords-safely-with-php-and-mysql/
-
-	// A higher $cost is more secure but consumes more processing power
-	$cost = 10;
-
-	// Create a random salt
-	if (extension_loaded('openssl')) {
-
-		$salt = strtr(substr(base64_encode(openssl_random_pseudo_bytes(17)),0,22), '+', '.');
-
-	} elseif (extension_loaded('mcrypt')) {
-
-		$salt = strtr(substr(base64_encode(mcrypt_create_iv(17, MCRYPT_DEV_URANDOM)),0,22), '+', '.');
-
-	} else {
-
-		$salt = '';
-
-		for ($i = 0; $i < 22; $i++) {
-			$salt .= substr("./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789", mt_rand(0, 63), 1);
-		}
-
-	}
-
-	// Prefix information about the hash so PHP knows how to verify it later.
-	// "$2a$" Means we're using the Blowfish algorithm. The following two digits are the cost parameter.
-	$salt = sprintf("$2a$%02d$", $cost) . $salt;
-
-	// Hash the password with the salt
-	return crypt($password, $salt);
-
+	return password_hash($password, PASSWORD_DEFAULT);
 }


### PR DESCRIPTION
Since the minimum requirement for Lychee is anyway 5.5+, switching to modern PHP password hashing methods made sense. This also fixes a security issue in the password reset flow, documented below. I haven't tested this for compatibility with the older stored passwords yet, but I'll do that if this is approved in principle.

- Uses password_hash and password_verify, both available since PHP5.5
- Fixes an incorrect password comparison in Settings.php which checked
the typed password against the stored hash directly
- Using password_verify ensures that the comparisons are now secure
against timing attacks.

Instead of using `$oldPassword===self::get()['password']`, now it
just compares it to a empty string. The earlier check would allow
someone with a database dump to reset the password without knowing it.