### PR TITLE
Base Docker Compose file to get people up and running ultra fast

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.3'
+
+services:
+   db:
+     image: mariadb:latest
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: password
+
+   lychee:
+     depends_on:
+       - db
+     volumes:
+       - config:/config
+       - pictures:/pictures
+     image: linuxserver/lychee:latest
+     ports:
+       - "8000:80"
+     restart: always
+     environment:
+       PGID: 1000
+       PUID: 1000
+volumes:
+  db_data:
+  config:
+  pictures:


### PR DESCRIPTION
A barrier to starting with Lychee is setting up the LAMP stack. This Docker Compose file allows someone to get started with a simple `docker-compose up -d` command.