### PR TITLE
Fix VIDEO_THUMB definition.

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -21,7 +21,7 @@ require(__DIR__ . '/autoload.php');
 if (file_exists(__DIR__ . '/../vendor/autoload.php' ))
 {
     include(__DIR__ . '/../vendor/autoload.php');
-    define('VIDEO_THUMB');
+    define('VIDEO_THUMB', True);
 }
 
 require(__DIR__ . '/helpers/fastImageCopyResampled.php');


### PR DESCRIPTION
The current `define('VIDEO_THUMB');` fails with `PHP message: PHP Warning:  define() expects at least 2 parameters, 1 given in /var/www/Lychee/php/index.php on line 24`
My install was always throwing the `Could not create thumbnail for video because FFMPEG is not available.` message, but adding this (and manually configuring php-ffmpeg) enabled thumbnail generation.
