### PR TITLE
Small pictures for Justified layout instead of Medium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,13 @@ data/config.php
 uploads/big/*
 uploads/import/*
 uploads/medium/*
+uploads/small/*
 uploads/thumb/*
 
 !uploads/big/index.html
 !uploads/import/index.html
 !uploads/medium/index.html
+!uploads/small/index.html
 !uploads/thumb/index.html
 
 plugins/*

--- a/php/Modules/Album.php
+++ b/php/Modules/Album.php
@@ -114,22 +114,22 @@ final class Album {
 
 			case 'f':
 				$return['public'] = '0';
-				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, type, width, height  FROM ? WHERE star = 1 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
+				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, type, width, height  FROM ? WHERE star = 1 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
 				break;
 
 			case 's':
 				$return['public'] = '0';
-				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, type, width, height  FROM ? WHERE public = 1 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
+				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, type, width, height  FROM ? WHERE public = 1 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
 				break;
 
 			case 'r':
 				$return['public'] = '0';
-				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, type, width, height  FROM ? WHERE LEFT(id, 10) >= unix_timestamp(DATE_SUB(NOW(), INTERVAL 1 DAY)) " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
+				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, type, width, height  FROM ? WHERE LEFT(id, 10) >= unix_timestamp(DATE_SUB(NOW(), INTERVAL 1 DAY)) " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
 				break;
 
 			case '0':
 				$return['public'] = '0';
-				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, type, width, height  FROM ? WHERE album = 0 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
+				$query = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, type, width, height  FROM ? WHERE album = 0 " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS));
 				break;
 
 			default:
@@ -137,7 +137,7 @@ final class Album {
 				$albums = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 				$return = $albums->fetch_assoc();
 				$return = Album::prepareData($return);
-				$query  = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, type, width, height FROM ? WHERE album = '?' " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS, $this->albumIDs));
+				$query  = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, type, width, height FROM ? WHERE album = '?' " . Settings::get()['sortingPhotos'], array(LYCHEE_TABLE_PHOTOS, $this->albumIDs));
 				break;
 
 		}

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -192,6 +192,7 @@ final class Photo {
 				$path       = $exists['path'];
 				$path_thumb = $exists['path_thumb'];
 				$medium     = ($exists['medium']==='1' ? 1 : 0);
+				$small      = ($exists['small']==='1' ? 1 : 0);
 				$exists     = true;
 			}
 
@@ -276,15 +277,18 @@ final class Photo {
 			// Create Medium
 			if ($this->createMedium($path, $photo_name, $info['type'], $info['width'], $info['height'])) $medium = 1;
 			else $medium = 0;
+			// Create Medium
+			if ($this->createMedium($path, $photo_name, $info['type'], $info['width'], $info['height'], 0, 360, 'SMALL')) $small = 1;
+			else $small = 0;
 		}
 
 		if(!in_array($file['type'], self::$validVideoTypes, true)){
-			$values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $info['description'], $info['tags'], $info['type'], $info['width'], $info['height'], $info['size'], $info['iso'], $info['aperture'], $info['make'], $info['model'], $info['shutter'], $info['focal'], $info['takestamp'], $path_thumb, $albumID, $public, $star, $checksum, $medium);
-			$query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium) VALUES ('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?')", $values);
+			$values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $info['description'], $info['tags'], $info['type'], $info['width'], $info['height'], $info['size'], $info['iso'], $info['aperture'], $info['make'], $info['model'], $info['shutter'], $info['focal'], $info['takestamp'], $path_thumb, $albumID, $public, $star, $checksum, $medium, $small);
+			$query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium, small) VALUES ('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?')", $values);
 			$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 		} else {
-            $values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $file['type'], $info['size'], time(),  $path_thumb, $albumID, $public, $star, $checksum, $medium);
-            $query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium) VALUES ('?', '?', '?', '', '', '?', 0, 0, '?', '', '', '', '', '', '', '?', '?', '?', '?', '?', '?', '?')", $values);
+            $values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $file['type'], $info['size'], time(),  $path_thumb, $albumID, $public, $star, $checksum, $medium, $small);
+            $query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium, small) VALUES ('?', '?', '?', '', '', '?', 0, 0, '?', '', '', '', '', '', '', '?', '?', '?', '?', '?', '?', '?', '?')", $values);
             $result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
         }
 
@@ -311,8 +315,8 @@ final class Photo {
 	private function exists($checksum, $photoID = null) {
 
 		// Exclude $photoID from select when $photoID is set
-		if (isset($photoID)) $query = Database::prepare(Database::get(), "SELECT id, url, thumbUrl, medium FROM ? WHERE checksum = '?' AND id <> '?' LIMIT 1", array(LYCHEE_TABLE_PHOTOS, $checksum, $photoID));
-		else                 $query = Database::prepare(Database::get(), "SELECT id, url, thumbUrl, medium FROM ? WHERE checksum = '?' LIMIT 1", array(LYCHEE_TABLE_PHOTOS, $checksum));
+		if (isset($photoID)) $query = Database::prepare(Database::get(), "SELECT id, url, thumbUrl, medium, small FROM ? WHERE checksum = '?' AND id <> '?' LIMIT 1", array(LYCHEE_TABLE_PHOTOS, $checksum, $photoID));
+		else                 $query = Database::prepare(Database::get(), "SELECT id, url, thumbUrl, medium, small FROM ? WHERE checksum = '?' LIMIT 1", array(LYCHEE_TABLE_PHOTOS, $checksum));
 
 		$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
@@ -326,7 +330,8 @@ final class Photo {
 				'photo_name' => $result->url,
 				'path'       => LYCHEE_UPLOADS_BIG . $result->url,
 				'path_thumb' => $result->thumbUrl,
-				'medium'     => $result->medium
+				'medium'     => $result->medium,
+				'small'	     => $result->small
 			);
 
 			return $return;
@@ -461,9 +466,14 @@ final class Photo {
 	/**
 	 * Creates a smaller version of a photo when its size is bigger than a preset size.
 	 * Photo must be big enough and Imagick must be installed and activated.
+	 *
+	 * Size of the medium-photo
+	 * When changing these values,
+	 * also change the size detection in the front-end
+	 *
 	 * @return boolean Returns true when successful.
 	 */
-	private function createMedium($url, $filename, $type, $width, $height) {
+	private function createMedium($url, $filename, $type, $width, $height, $newWidth  = 1920, $newHeight = 1080, $kind = 'MEDIUM') {
 
 		// Excepts the following:
 		// (string) $url = Path to the photo-file
@@ -480,17 +490,19 @@ final class Photo {
 		// Set to true when creation of medium-photo failed
 		$error = false;
 
-		// Size of the medium-photo
-		// When changing these values,
-		// also change the size detection in the front-end
-		$newWidth  = 1920;
-		$newHeight = 1080;
 
 		// Check permissions
-		if (hasPermissions(LYCHEE_UPLOADS_MEDIUM)===false) {
+		if ($kind == 'MEDIUM' && hasPermissions(LYCHEE_UPLOADS_MEDIUM)===false) {
 
 			// Permissions are missing
 			Log::notice(Database::get(), __METHOD__, __LINE__, 'Skipped creation of medium-photo, because uploads/medium/ is missing or not readable and writable.');
+			return false;
+
+		}
+		if ($kind == 'SMALL' && hasPermissions(LYCHEE_UPLOADS_SMALL)===false) {
+
+			// Permissions are missing
+			Log::notice(Database::get(), __METHOD__, __LINE__, 'Skipped creation of small-photo, because uploads/small/ is missing or not readable and writable.');
 			return false;
 
 		}
@@ -512,14 +524,14 @@ final class Photo {
 			$medium->readImage($url);
 
 			// Adjust image
-			$medium->scaleImage($newWidth, $newHeight, true);
+			$medium->scaleImage($newWidth, $newHeight, ($newWidth == 0));
 			$medium->stripImage();
 			$medium->setImageCompressionQuality($quality);
 
 			// Save image
 			try { $medium->writeImage($newUrl); }
 			catch (ImagickException $err) {
-				Log::notice(Database::get(), __METHOD__, __LINE__, 'Could not save medium-photo (' . $err->getMessage() . ')');
+				Log::notice(Database::get(), __METHOD__, __LINE__, 'Could not save '.$kind.'-photo (' . $err->getMessage() . ')');
 				$error = true;
 			}
 
@@ -533,8 +545,15 @@ final class Photo {
 			Log::notice(Database::get(), __METHOD__, __LINE__, 'Picture is big enough for resize, try with GD!');
 			// failed with imagick, try with GD
 
-	        // Create image
-	        $newHeight = $newWidth/($width/$height);
+			// Create image
+	        if($newWidth == 0)
+	        {
+		        $newWidth = $newHeight*($width/$height);
+	        }
+	        else
+	        {
+		        $newHeight = $newWidth/($width/$height);
+	        }
 	        $medium   = imagecreatetruecolor($newWidth, $newHeight);
 	        // Create new image
 	        switch($type) {
@@ -819,6 +838,10 @@ final class Photo {
 		// Parse medium
 		if ($photo['medium']==='1') $photo['medium'] = LYCHEE_URL_UPLOADS_MEDIUM . $photo['url'];
 		else                        $photo['medium'] = '';
+		// Parse small
+		if ($photo['small']==='1') $photo['small'] = LYCHEE_URL_UPLOADS_MEDIUM . $photo['url'];
+		else                        $photo['small'] = '';
+
 
 		// Parse paths
 		$photo['url']      = LYCHEE_URL_UPLOADS_BIG . $photo['url'];

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -277,13 +277,14 @@ final class Photo {
 			// Create Medium
 			if ($this->createMedium($path, $photo_name, $info['type'], $info['width'], $info['height'])) $medium = 1;
 			else $medium = 0;
-			// Create Medium
+			// Create Small
 			if ($this->createMedium($path, $photo_name, $info['type'], $info['width'], $info['height'], 0, 360, 'SMALL')) $small = 1;
 			else $small = 0;
 		}
 
 		if(!in_array($file['type'], self::$validVideoTypes, true)){
-			$values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $info['description'], $info['tags'], $info['type'], $info['width'], $info['height'], $info['size'], $info['iso'], $info['aperture'], $info['make'], $info['model'], $info['shutter'], $info['focal'], $info['takestamp'], $path_thumb, $albumID, $public, $star, $checksum, $medium, $small);
+			$values = array(LYCHEE_TABLE_PHOTOS, $id, $info['title'], $photo_name, $info['description'], $info['tags'], $info['type'], $info['width'], $info['height'], $info['size'], $info['iso'],
+			$info['aperture'], $info['make'], $info['model'], $info['shutter'], $info['focal'], $info['takestamp'], $path_thumb, $albumID, $public, $star, $checksum, $medium, $small);
 			$query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium, small) VALUES ('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?')", $values);
 			$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 		} else {
@@ -514,7 +515,15 @@ final class Photo {
 		    return false;
 	    }
 
-		$newUrl = LYCHEE_UPLOADS_MEDIUM . $filename;
+		$newUrl = '';
+		if($kind == 'SMALL')
+		{
+			$newUrl = LYCHEE_UPLOADS_SMALL . $filename;
+		}
+		else
+		{
+			$newUrl = LYCHEE_UPLOADS_MEDIUM . $filename;
+		}
 
 		// Is Imagick installed and activated?
 		if (extension_loaded('imagick')&&Settings::get()['imagick']==='1') {
@@ -524,7 +533,7 @@ final class Photo {
 			$medium->readImage($url);
 
 			// Adjust image
-			$medium->scaleImage($newWidth, $newHeight, ($newWidth == 0));
+			$medium->scaleImage($newWidth, $newHeight, ($newWidth != 0));
 			$medium->stripImage();
 			$medium->setImageCompressionQuality($quality);
 
@@ -778,6 +787,10 @@ final class Photo {
 		// Parse medium
 		if ($data['medium']==='1') $photo['medium'] = LYCHEE_URL_UPLOADS_MEDIUM . $data['url'];
 		else                       $photo['medium'] = '';
+
+		// Parse medium
+		if ($data['small']==='1') $photo['small'] = LYCHEE_URL_UPLOADS_SMALL . $data['url'];
+		else                       $photo['small'] = '';
 
 		// Parse paths
 		$photo['thumbUrl'] = LYCHEE_URL_UPLOADS_THUMB . $data['thumbUrl'];
@@ -1363,7 +1376,7 @@ final class Photo {
 
 			// Duplicate entry
 			$values = array(LYCHEE_TABLE_PHOTOS, $id, LYCHEE_TABLE_PHOTOS, $photo->id);
-			$query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum) SELECT '?' AS id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum FROM ? WHERE id = '?'", $values);
+			$query  = Database::prepare(Database::get(), "INSERT INTO ? (id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium, small) SELECT '?' AS id, title, url, description, tags, type, width, height, size, iso, aperture, make, model, shutter, focal, takestamp, thumbUrl, album, public, star, checksum, medium, small FROM ? WHERE id = '?'", $values);
 			$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
 			if ($result===false) $error = true;

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -788,7 +788,7 @@ final class Photo {
 		if ($data['medium']==='1') $photo['medium'] = LYCHEE_URL_UPLOADS_MEDIUM . $data['url'];
 		else                       $photo['medium'] = '';
 
-		// Parse medium
+		// Parse small
 		if ($data['small']==='1') $photo['small'] = LYCHEE_URL_UPLOADS_SMALL . $data['url'];
 		else                       $photo['small'] = '';
 
@@ -851,10 +851,6 @@ final class Photo {
 		// Parse medium
 		if ($photo['medium']==='1') $photo['medium'] = LYCHEE_URL_UPLOADS_MEDIUM . $photo['url'];
 		else                        $photo['medium'] = '';
-		// Parse small
-		if ($photo['small']==='1') $photo['small'] = LYCHEE_URL_UPLOADS_MEDIUM . $photo['url'];
-		else                        $photo['small'] = '';
-
 
 		// Parse paths
 		$photo['url']      = LYCHEE_URL_UPLOADS_BIG . $photo['url'];

--- a/php/database/update_030203.php
+++ b/php/database/update_030203.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Update to version 3.2.3
+ */
+
+use Lychee\Modules\Database;
+use Lychee\Modules\Response;
+
+// Add small to photos
+$query  = Database::prepare($connection, "SELECT `small` FROM `?` LIMIT 1", array(LYCHEE_TABLE_PHOTOS));
+$result = Database::execute($connection, $query, 'update_030203', __LINE__);
+
+if ($result===false) {
+
+	$query  = Database::prepare($connection, "ALTER TABLE `?` ADD `small` TINYINT(1) NOT NULL DEFAULT 0", array(LYCHEE_TABLE_PHOTOS));
+	$result = Database::execute($connection, $query, 'update_030203', __LINE__);
+
+	if ($result===false) Response::error('Could not add small-field to database!');
+
+}
+
+// Set version
+if (Database::setVersion($connection, '030203')===false) Response::error('Could not update version of database!');

--- a/php/database/update_030203.php
+++ b/php/database/update_030203.php
@@ -21,4 +21,4 @@ if ($result===false) {
 }
 
 // Set version
-if (Database::setVersion($connection, '030203')===false) Response::error('Could not update version of database!');
+if (Database::setVersion($connection, 'update_030203')===false) Response::error('Could not update version of database!');

--- a/php/define.php
+++ b/php/define.php
@@ -14,6 +14,7 @@ define('LYCHEE_SRC', LYCHEE . 'Lychee-front/');
 define('LYCHEE_UPLOADS', LYCHEE . 'uploads/');
 define('LYCHEE_UPLOADS_BIG', LYCHEE_UPLOADS . 'big/');
 define('LYCHEE_UPLOADS_MEDIUM', LYCHEE_UPLOADS . 'medium/');
+define('LYCHEE_UPLOADS_MEDIUM', LYCHEE_UPLOADS . 'small/');
 define('LYCHEE_UPLOADS_THUMB', LYCHEE_UPLOADS . 'thumb/');
 define('LYCHEE_UPLOADS_IMPORT', LYCHEE_UPLOADS . 'import/');
 define('LYCHEE_PLUGINS', LYCHEE . 'plugins/');
@@ -24,6 +25,7 @@ define('LYCHEE_CONFIG_FILE', LYCHEE_DATA . 'config.php');
 // Define urls
 define('LYCHEE_URL_UPLOADS_BIG', 'uploads/big/');
 define('LYCHEE_URL_UPLOADS_MEDIUM', 'uploads/medium/');
+define('LYCHEE_URL_UPLOADS_SMALL', 'uploads/small/');
 define('LYCHEE_URL_UPLOADS_THUMB', 'uploads/thumb/');
 
 function defineTablePrefix($dbTablePrefix) {

--- a/php/define.php
+++ b/php/define.php
@@ -14,7 +14,7 @@ define('LYCHEE_SRC', LYCHEE . 'Lychee-front/');
 define('LYCHEE_UPLOADS', LYCHEE . 'uploads/');
 define('LYCHEE_UPLOADS_BIG', LYCHEE_UPLOADS . 'big/');
 define('LYCHEE_UPLOADS_MEDIUM', LYCHEE_UPLOADS . 'medium/');
-define('LYCHEE_UPLOADS_MEDIUM', LYCHEE_UPLOADS . 'small/');
+define('LYCHEE_UPLOADS_SMALL', LYCHEE_UPLOADS . 'small/');
 define('LYCHEE_UPLOADS_THUMB', LYCHEE_UPLOADS . 'thumb/');
 define('LYCHEE_UPLOADS_IMPORT', LYCHEE_UPLOADS . 'import/');
 define('LYCHEE_PLUGINS', LYCHEE . 'plugins/');

--- a/plugins/Diagnostics/index.php
+++ b/plugins/Diagnostics/index.php
@@ -47,6 +47,7 @@ if (!extension_loaded('zip'))      $error .= ('Error: PHP zip extension not acti
 
 // Permissions
 if (hasPermissions(LYCHEE_UPLOADS_BIG)===false)    $error .= ('Error: \'uploads/big\' is missing or has insufficient read/write privileges' . PHP_EOL);
+if (hasPermissions(LYCHEE_UPLOADS_SMALL)===false)  $error .= ('Error: \'uploads/small\' is missing or has insufficient read/write privileges' . PHP_EOL);
 if (hasPermissions(LYCHEE_UPLOADS_MEDIUM)===false) $error .= ('Error: \'uploads/medium\' is missing or has insufficient read/write privileges' . PHP_EOL);
 if (hasPermissions(LYCHEE_UPLOADS_THUMB)===false)  $error .= ('Error: \'uploads/thumb\' is missing or has insufficient read/write privileges' . PHP_EOL);
 if (hasPermissions(LYCHEE_UPLOADS_IMPORT)===false) $error .= ('Error: \'uploads/import\' is missing or has insufficient read/write privileges' . PHP_EOL);


### PR DESCRIPTION
Loading medium pictures in the album view in case of Justified Layout is making the website slow.
We now create *small* pictures with 360px high (otherwise panorama do not look nice). Those are used to be displayed in Justified Layout if available.