### PR TITLE
Fixes bug when enabling justified layout in 3.2.4

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -4665,7 +4665,7 @@ settings.changeLayout = function () {
 	} else {
 		params.justified_layout = '0';
 	}
-	api.post('Settings::setLayoutOverlay', params, function (data) {
+	api.post('Settings::setLayout', params, function (data) {
 		if (data === true) {
 			loadingBar.show('success', lychee.locale['SETTINGS_SUCCESS_LAYOUT']);
 			lychee.justified = params.justified_layout === '1';


### PR DESCRIPTION
Enabling justified layout after updating to 3.2.4 throws an error
about a misspelled function.

`Settings::setLayoutOverlay` doesn't match the PHP function in the
Settings module, so an error is shown when the UI switch is toggled. Renaming to `Settings::setLayout` fixes the bug.