### PR TITLE
Create the db tables with InnoDB storage engine

### DIFF
--- a/php/database/albums_table.sql
+++ b/php/database/albums_table.sql
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS `?` (
   `min_takestamp` int(11) NOT NULL,
   `max_takestamp` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/database/log_table.sql
+++ b/php/database/log_table.sql
@@ -9,4 +9,4 @@ CREATE TABLE IF NOT EXISTS `?` (
   `line` int(11) NOT NULL,
   `text` text,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/database/photos_table.sql
+++ b/php/database/photos_table.sql
@@ -27,4 +27,4 @@ CREATE TABLE IF NOT EXISTS `?` (
   PRIMARY KEY (`id`),
   KEY `Index_album` (`album`),
   KEY `Index_star` (`star`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/php/database/settings_table.sql
+++ b/php/database/settings_table.sql
@@ -4,4 +4,4 @@
 CREATE TABLE IF NOT EXISTS `?` (
   `key` varchar(50) NOT NULL DEFAULT '',
   `value` varchar(200) DEFAULT ''
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Since the integrity of the `photos_table` and the rest of the tables is vital for running Lychee I suggest moving to the InnoDB storage engine.

Using MyISAM is contraindicated as it's not crash safe(one can lose data when the under
lying database crashes) and it only supports table level locking(backup will cause longer lock). 
The InnoDB is a modern storage engine that uses doublewrite buffer and redo log to achieve durability and crash safety.

Changing the storage engine doesn't need any application code changes.

The existing tables can be converted with
`ALTER TABLE x engine=InnoDB;`

This is a locking operation, but it won't take longer than a couple of seconds for a table with 10.000 rows, somebody with a really large (1 million photos) deployment might want to use [pt-osc](https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html) if having a downtime is not possible.
