### PR TITLE
Add setting for php_script_limit. Fixes #177

### DIFF
--- a/php/Modules/Import.php
+++ b/php/Modules/Import.php
@@ -98,6 +98,13 @@ final class Import {
 	 */
 	public function server($path, $albumID = 0) {
 
+		// Fixes #177
+		$php_script_limit = Settings::get()['php_script_limit'];
+		if ($php_script_limit == 1) {
+			set_time_limit(0);
+			Log::notice(Database::get(), __METHOD__, __LINE__, 'Importing using unlimited execution time');
+		}
+
 		// Parse path
 		if (!isset($path))           $path = LYCHEE_UPLOADS_IMPORT;
 		if (substr($path, -1)==='/') $path = substr($path, 0, -1);

--- a/php/Modules/Session.php
+++ b/php/Modules/Session.php
@@ -53,6 +53,7 @@ final class Session {
 			unset($return['config']['location']);
 			unset($return['config']['imagick']);
 			unset($return['config']['plugins']);
+			unset($return['config']['php_script_limit']);
 
 		}
 

--- a/php/database/update_030211.php
+++ b/php/database/update_030211.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Update to version 3.2.11
+ */
+
+ use Lychee\Modules\Database;
+ use Lychee\Modules\Response;
+ // Add lang to settings
+ $query  = Database::prepare($connection, "SELECT `key` FROM `?` WHERE `key` = 'php_script_limit' LIMIT 1", array(LYCHEE_TABLE_SETTINGS));
+ $result = Database::execute($connection, $query, 'update_030211', __LINE__);
+ if ($result===false) Response::error('Could not get current php_script_limit from database!');
+ if ($result->num_rows===0) {
+ 	$query  = Database::prepare($connection, "INSERT INTO `?` (`key`, `value`) VALUES ('php_script_limit', '0')", array(LYCHEE_TABLE_SETTINGS));
+ 	$result = Database::execute($connection, $query, 'update_030211', __LINE__);
+ 	if ($result===false) Response::error('Could not add php_script_limit to database!');
+ }
+ // Set version
+ if (Database::setVersion($connection, 'update_030211')===false) Response::error('Could not update version of database!');


### PR DESCRIPTION
Added setting to allow for unlimited script run time for LARGE data imports. The values are 1 for on and 0 for off.

Tested using local environment...
With setting "0", 65 photos imported before script timeout of 200 sec.
With setting "1", it is still going at 431 photos...

This can have negative implications if left on, due to giving the script unlimited run time. I would recommend to set to 1 only when needed, and to reset to 0 when done. The default value when database is updated is 0 for off.