### PR TITLE
Add usage of exiftool to get exif tags from camera manufactures

### DIFF
--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -1061,15 +1061,18 @@ final class Photo {
 		// Read EXIF
 		if ($info['mime']=='image/jpeg') {
 			$exif = false;
-			system('which exiftool 2>&1 > /dev/null', $status);
-			if ($status == 0) {
-				$handle = @popen("exiftool -php -q $url 2>&1", 'r');
-				$exiftool = @fread($handle, 8192);
-				@pclose($handle);
-				if (false!==$exiftool && strlen($exiftool) > 0) {
-					$exiftool = @eval('return ' . "$exiftool");
-					if (is_array($exiftool) && is_array($exiftool[0])) {
-						$exif = $exiftool[0];
+			if(Settings::useExiftool()) {
+				Log::notice(Database::get(), __METHOD__, __LINE__, 'Using exiftool');
+				system('which exiftool 2>&1 > /dev/null', $status);
+				if ($status == 0) {
+					$handle = @popen("exiftool -php -q $url 2>&1", 'r');
+					$exiftool = @fread($handle, 8192);
+					@pclose($handle);
+					if (false!==$exiftool && strlen($exiftool) > 0) {
+						$exiftool = @eval('return ' . "$exiftool");
+						if (is_array($exiftool) && is_array($exiftool[0])) {
+							$exif = $exiftool[0];
+						}
 					}
 				}
 			}

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -1063,16 +1063,13 @@ final class Photo {
 			$exif = false;
 			if(Settings::useExiftool()) {
 				Log::notice(Database::get(), __METHOD__, __LINE__, 'Using exiftool');
-				system('which exiftool 2>&1 > /dev/null', $status);
-				if ($status == 0) {
-					$handle = @popen("exiftool -php -q $url 2>&1", 'r');
-					$exiftool = @fread($handle, 8192);
-					@pclose($handle);
-					if (false!==$exiftool && strlen($exiftool) > 0) {
-						$exiftool = @eval('return ' . "$exiftool");
-						if (is_array($exiftool) && is_array($exiftool[0])) {
-							$exif = $exiftool[0];
-						}
+				$handle = @popen("exiftool -php -q $url 2>&1", 'r');
+				$exiftool = @fread($handle, 8192);
+				@pclose($handle);
+				if (false!==$exiftool && strlen($exiftool) > 0) {
+					$exiftool = @eval('return ' . "$exiftool");
+					if (is_array($exiftool) && is_array($exiftool[0])) {
+						$exif = $exiftool[0];
 					}
 				}
 			}

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -1065,9 +1065,9 @@ final class Photo {
 			if ($status == 0) {
 				$handle = @popen("exiftool -php -q $url 2>&1", 'r');
 				$exiftool = @fread($handle, 8192);
+				@pclose($handle);
 				if (false!==$exiftool && strlen($exiftool) > 0) {
 					$exiftool = @eval('return ' . "$exiftool");
-					@pclose($handle);
 					if (is_array($exiftool) && is_array($exiftool[0])) {
 						$exif = $exiftool[0];
 					}

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -1059,7 +1059,26 @@ final class Photo {
 		}
 
 		// Read EXIF
-		if ($info['mime']=='image/jpeg') $exif = @exif_read_data($url, 'EXIF', false, false);
+		if ($info['mime']=='image/jpeg') {
+			$exif = false;
+			system('which exiftool 2>&1 > /dev/null', $status);
+			if ($status == 0) {
+				$handle = @popen("exiftool -php -q $url 2>&1", 'r');
+				$exiftool = @fread($handle, 8192);
+				if (false!==$exiftool && strlen($exiftool) > 0) {
+					$exiftool = @eval('return ' . "$exiftool");
+					@pclose($handle);
+					if (is_array($exiftool) && is_array($exiftool[0])) {
+						$exif = $exiftool[0];
+					}
+				}
+			}
+			// If exiftool is not available
+			// or using exiftool fails in any way fallback to exif_read_data
+			if (!is_array($exif)) {
+				$exif = @exif_read_data($url, 'EXIF', false, false);
+			}
+		}
 		else $exif = false;
 
 		// EXIF Metadata
@@ -1071,9 +1090,11 @@ final class Photo {
 
 			// ISO
 			if (!empty($exif['ISOSpeedRatings'])) $return['iso'] = $exif['ISOSpeedRatings'];
+			else if (!empty($exif['ISO'])) $return['iso'] = trim($exif['ISO']);
 
 			// Aperture
 			if (!empty($exif['COMPUTED']['ApertureFNumber'])) $return['aperture'] = $exif['COMPUTED']['ApertureFNumber'];
+			else if (!empty($exif['Aperture'])) $return['aperture'] = 'f/' . trim($exif['Aperture']);
 
 			// Make
 			if (!empty($exif['Make'])) $return['make'] = trim($exif['Make']);
@@ -1091,6 +1112,9 @@ final class Photo {
 					$temp = $temp[0] / $temp[1];
 					$temp = round($temp, 1);
 					$return['focal'] = $temp . ' mm';
+				} else if (strpos($exif['FocalLength'], 'mm')!==false) {
+					$temp = substr($exif['FocalLength'], 0, strpos($exif['FocalLength'], '.'));
+					$return['focal'] = $temp . ' mm';
 				} else {
 					$return['focal'] = $exif['FocalLength'] . ' mm';
 				}
@@ -1107,6 +1131,7 @@ final class Photo {
             }
 
 			if (!empty($exif['LensInfo'])) $return['lens'] = trim($exif['LensInfo']);
+			else if(!empty($exif['Lens'])) $return['lens'] = trim($exif['Lens']);
 
 			// Lens field from Lightroom
 			if ($return['lens'] == '' && !empty($exif['UndefinedTag:0xA434'])) $return['lens'] = trim($exif['UndefinedTag:0xA434']);

--- a/php/Modules/Session.php
+++ b/php/Modules/Session.php
@@ -54,6 +54,7 @@ final class Session {
 			unset($return['config']['imagick']);
 			unset($return['config']['plugins']);
 			unset($return['config']['php_script_limit']);
+			unset($return['config']['useExiftool']);
 
 		}
 

--- a/php/Modules/Settings.php
+++ b/php/Modules/Settings.php
@@ -349,4 +349,20 @@ final class Settings {
 		return false;
 	}
 
+        /**
+         * @return bool Returns the useExiftool setting.
+         */
+        public static function useExiftool() {
+                return (bool) (self::get()['useExiftool'] === '1');
+        }
+
+        /**
+         * @return bool Set the useExiftool setting.
+         */
+        public static function setUseExiftool($enable) {
+		Log::notice(Database::get(), __METHOD__, __LINE__, 'Change useExiftool to: ' . $enable);
+		if (self::set('useExiftool', $enable)===false) return false;
+                return true;
+        }
+
 }

--- a/php/Modules/Settings.php
+++ b/php/Modules/Settings.php
@@ -356,13 +356,4 @@ final class Settings {
                 return (bool) (self::get()['useExiftool'] === '1');
         }
 
-        /**
-         * @return bool Set the useExiftool setting.
-         */
-        public static function setUseExiftool($enable) {
-		Log::notice(Database::get(), __METHOD__, __LINE__, 'Change useExiftool to: ' . $enable);
-		if (self::set('useExiftool', $enable)===false) return false;
-                return true;
-        }
-
 }

--- a/php/Modules/Settings.php
+++ b/php/Modules/Settings.php
@@ -353,6 +353,8 @@ final class Settings {
          * @return bool Returns the useExiftool setting.
          */
         public static function useExiftool() {
+                system('which exiftool 2>&1 > /dev/null', $status);
+                if ($status != 0) return false;
                 return (bool) (self::get()['useExiftool'] === '1');
         }
 

--- a/php/database/update_030212.php
+++ b/php/database/update_030212.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Update to version 3.2.12
+ */
+
+use Lychee\Modules\Database;
+use Lychee\Modules\Response;
+
+// Add useExiftool to settings
+$query  = Database::prepare($connection, "SELECT `key` FROM `?` WHERE `key` = 'useExiftool' LIMIT 1", array(LYCHEE_TABLE_SETTINGS));
+$result = Database::execute($connection, $query, 'update_030212', __LINE__);
+
+if ($result===false) Response::error('Could not get useExiftool from database!');
+
+if ($result->num_rows===0) {
+
+   $query  = Database::prepare($connection, "INSERT INTO `?` (`key`, `value`) VALUES ('useExiftool', '0')", array(LYCHEE_TABLE_SETTINGS));
+   $result = Database::execute($connection, $query, 'update_030212', __LINE__);
+
+   if ($result===false) Response::error('Could not add useExiftool to database!');
+}
+
+
+// Set version
+if (Database::setVersion($connection, 'update_030212')===false) Response::error('Could not update version of database!');


### PR DESCRIPTION
Using exiftool for getting exif tags make available a lot more tags than the built-in functionality in PHP. Using exiftool will make eg. lens info available without having to rely on that users have exported a raw from Ligthroom.

Signed-off-by: Michael Rasmussen <mir@datanom.net>