### PR TITLE
Skip processing the default shutter value

### DIFF
--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -830,7 +830,7 @@ final class Photo {
 		$photo['lens']   		= isset($data['lens']) ? $data['lens'] : ''; // isset should not be needed
 
 
-		if($photo['shutter'] != '' && substr($photo['shutter'], 0,2) != '1/'){
+		if($photo['shutter'] != '' && substr($photo['shutter'], 0,2) != '1/' && $photo['shutter'] != 'None'){
 
 			// this should fix it... hopefully.
 			preg_match('/(\d+)\/(\d+) s/', $photo['shutter'], $matches);


### PR DESCRIPTION
I've noticed that some of my photos fail to load
and the JS console says "Internal Server Error".

Upon looking into the database, I've noticed that
those photos have `None` as value for the `shutter`
column, which seems to be the default value for
that column.

The "Internal Server Error" comes from division
by zero - in the `if` block it's trying to parse the
shutter value to ints, which fails because it's a
string and then the function `gcd()` is called with
`0,0`, throwing the division by zero error.

This makes it just skip parsing the shutter value
if it's the database default, which is `None`.