### PR TITLE
Settings pk

### DIFF
--- a/php/database/update_030214.php
+++ b/php/database/update_030214.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Update to version 3.2.14
+ */
+
+use Lychee\Modules\Database;
+use Lychee\Modules\Response;
+
+$query  = Database::prepare($connection, "ALTER TABLE `?` ADD PRIMARY KEY( `key`); ", array(LYCHEE_TABLE_SETTINGS));
+$result = Database::execute($connection, $query, 'update_030214', __LINE__);
+
+if ($result===false) Response::error('Could not add primary key to settings!');
+
+// Set version
+if (Database::setVersion($connection, 'update_030214')===false) Response::error('Could not update version of database!');

--- a/php/database/update_030214.php
+++ b/php/database/update_030214.php
@@ -18,7 +18,7 @@ $result = Database::execute($connection, $query, 'update_030214', __LINE__);
 if ($result->num_rows===0) {
 
 	$query  = Database::prepare($connection, "INSERT INTO `?` (`key`, `value`) VALUES ('full_photo', '1')", array(LYCHEE_TABLE_SETTINGS));
-	$result = Database::execute($connection, $query, 'update_030213', __LINE__);
+	$result = Database::execute($connection, $query, 'update_030214', __LINE__);
 
 	if ($result===false) Response::error('Could not insert setting key full_photo!');
 }

--- a/php/database/update_030214.php
+++ b/php/database/update_030214.php
@@ -10,7 +10,7 @@ use Lychee\Modules\Response;
 $query  = Database::prepare($connection, "ALTER TABLE `?` ADD PRIMARY KEY( `key`); ", array(LYCHEE_TABLE_SETTINGS));
 $result = Database::execute($connection, $query, 'update_030214', __LINE__);
 
-if ($result===false) Response::error('Could not add primary key to settings!');
+if ($result===false) Response::error('Could not add primary key to settings! Clean up duplicate setting keys!');
 
 // Set version
 if (Database::setVersion($connection, 'update_030214')===false) Response::error('Could not update version of database!');

--- a/php/database/update_030214.php
+++ b/php/database/update_030214.php
@@ -12,5 +12,16 @@ $result = Database::execute($connection, $query, 'update_030214', __LINE__);
 
 if ($result===false) Response::error('Could not add primary key to settings! Clean up duplicate setting keys!');
 
+$query  = Database::prepare($connection, "SELECT `key` FROM `?` WHERE `key` = 'full_photo' LIMIT 1", array(LYCHEE_TABLE_SETTINGS));
+$result = Database::execute($connection, $query, 'update_030214', __LINE__);
+
+if ($result->num_rows===0) {
+
+	$query  = Database::prepare($connection, "INSERT INTO `?` (`key`, `value`) VALUES ('full_photo', '1')", array(LYCHEE_TABLE_SETTINGS));
+	$result = Database::execute($connection, $query, 'update_030213', __LINE__);
+
+	if ($result===false) Response::error('Could not insert setting key full_photo!');
+}
+
 // Set version
 if (Database::setVersion($connection, 'update_030214')===false) Response::error('Could not update version of database!');


### PR DESCRIPTION
Not a functional addition, but rather a change for consistency:
Add a primary key for the settings table as well.

This will reduce potential misbehavior as setting keys can no longer be set more than once.
This update will fail on installations where the settings are already messed up.