### PR TITLE
Generated IDs should now always be microtime*10000.

### DIFF
--- a/php/helpers/generateID.php
+++ b/php/helpers/generateID.php
@@ -6,10 +6,7 @@
 function generateID() {
 
 	// Generate id based on the current microtime
-	$id = str_replace('.', '', microtime(true));
-
-	// Ensure that the id has a length of 14 chars
-	while(strlen($id)<14) $id .= 0;
+	$id = str_replace('.', '', sprintf("%015.4f", microtime(true)));
 
 	// Return id as a string. Don't convert the id to an integer
 	// as 14 digits are too big for 32bit PHP versions.


### PR DESCRIPTION
Technically this hasn't been a problem since 2001, but adding here for completeness' sake.
Heavily based on LycheeOrg/Lychee-Laravel#155 by @kamil4.