### PR TITLE
Tweak output format for search

### DIFF
--- a/php/helpers/search.php
+++ b/php/helpers/search.php
@@ -21,15 +21,17 @@ function search($term) {
 	 * Photos
 	 */
 
-	$query  = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium FROM ? WHERE title LIKE '%?%' OR description LIKE '%?%' OR tags LIKE '%?%'", array(LYCHEE_TABLE_PHOTOS, $term, $term, $term));
+	$query  = Database::prepare(Database::get(), "SELECT id, title, tags, public, star, album, thumbUrl, takestamp, url, medium, small, width, height FROM ? WHERE title LIKE '%?%' OR description LIKE '%?%' OR tags LIKE '%?%'", array(LYCHEE_TABLE_PHOTOS, $term, $term, $term));
 	$result = Database::execute(Database::get(), $query, __METHOD__, __LINE__);
 
 	if ($result===false) return false;
 
+	$i = 0;
 	while($photo = $result->fetch_assoc()) {
 
 		$photo = Photo::prepareData($photo);
-		$return['photos'][$photo['id']] = $photo;
+		$return['photos'][$i] = $photo;
+		$i++;
 
 	}
 
@@ -42,6 +44,7 @@ function search($term) {
 
 	if ($result===false) return false;
 
+	$i = 0;
 	while($album = $result->fetch_assoc()) {
 
 		// Turn data from the database into a front-end friendly format
@@ -61,7 +64,8 @@ function search($term) {
 		}
 
 		// Add to return
-		$return['albums'][$album['id']] = $album;
+		$return['albums'][$i] = $album;
+		$i++;
 
 	}
 


### PR DESCRIPTION
The response to search commands is missing photos' `width` and `height`, and the photos are indexed using `id` rather than plain index starting from `0`, as the code in the front end expects. This prevents other photo layouts than square thumbnails from working properly (I will be submitting matching patches to the front end).