### PR TITLE
Eliminate albumID from Photo::get

### DIFF
--- a/php/Access/Admin.php
+++ b/php/Access/Admin.php
@@ -166,10 +166,10 @@ final class Admin extends Access {
 
 	private static function getPhotoAction() {
 
-		Validator::required(isset($_POST['photoID'], $_POST['albumID']), __METHOD__);
+		Validator::required(isset($_POST['photoID']), __METHOD__);
 
 		$photo = new Photo($_POST['photoID']);
-		Response::json($photo->get($_POST['albumID']));
+		Response::json($photo->get());
 
 	}
 

--- a/php/Access/Guest.php
+++ b/php/Access/Guest.php
@@ -99,13 +99,13 @@ final class Guest extends Access {
 
 	private static function getPhotoAction() {
 
-		Validator::required(isset($_POST['photoID'], $_POST['albumID'], $_POST['password']), __METHOD__);
+		Validator::required(isset($_POST['photoID'], $_POST['password']), __METHOD__);
 
 		$photo = new Photo($_POST['photoID']);
 
 		$pgP = $photo->getPublic($_POST['password']);
 
-		if ($pgP===2)      Response::json($photo->get($_POST['albumID']));
+		if ($pgP===2)      Response::json($photo->get());
 		else if ($pgP===1) Response::warning('Wrong password!');
 		else if ($pgP===0) Response::warning('Photo private!');
 

--- a/php/Modules/Photo.php
+++ b/php/Modules/Photo.php
@@ -913,10 +913,7 @@ final class Photo {
 	/**
 	 * @return array|false Returns an array with information about the photo or false on failure.
 	 */
-	public function get($albumID) {
-
-		// Excepts the following:
-		// (string) $albumID = Album which is currently visible to the user
+	public function get() {
 
 		// Check dependencies
 		Validator::required(isset($this->photoIDs), __METHOD__);
@@ -954,7 +951,7 @@ final class Photo {
 		// $photo['url']      = LYCHEE_URL_UPLOADS_BIG . $photo['url'];
 		// $photo['thumbUrl'] = LYCHEE_URL_UPLOADS_THUMB . $photo['thumbUrl'];
 
-		if ($albumID!='false') {
+		if (true) {
 
 			// Only show photo as public when parent album is public
 			// Check if parent album is not 'Unsorted'
@@ -979,9 +976,6 @@ final class Photo {
 				$photo['public'] = ($album['public']==='1' ? '2' : $photo['public']);
 
 			}
-
-			$photo['original_album'] = $photo['album'];
-			$photo['album']          = $albumID;
 
 		}
 


### PR DESCRIPTION
This is a backport of https://github.com/LycheeOrg/Lychee-Laravel/pull/296/commits/f9ae89363a0999415a4acea4a9e0aad745dc8d01 from https://github.com/LycheeOrg/Lychee-Laravel/pull/296.

In short, I had to modify the front end to make the standalone view mode work with v4. The change simplifies the client-server interaction in `Photo::get` but it means that it does require changes on the server side since one less parameter is now passed.